### PR TITLE
Add header for Jelly status

### DIFF
--- a/JellyDemo/Source/JellyDemo/JellyActor.cpp
+++ b/JellyDemo/Source/JellyDemo/JellyActor.cpp
@@ -1,0 +1,27 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "JellyActor.h"
+
+// Sets default values
+AJellyActor::AJellyActor()
+{
+ 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	PrimaryActorTick.bCanEverTick = true;
+
+}
+
+// Called when the game starts or when spawned
+void AJellyActor::BeginPlay()
+{
+	Super::BeginPlay();
+	
+}
+
+// Called every frame
+void AJellyActor::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+

--- a/JellyDemo/Source/JellyDemo/JellyActor.h
+++ b/JellyDemo/Source/JellyDemo/JellyActor.h
@@ -1,0 +1,28 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "JellyStatus.h"
+#include "JellyActor.generated.h"
+
+UCLASS()
+class JELLYDEMO_API AJellyActor : public AActor
+{
+	GENERATED_BODY()
+	
+public:	
+	// Sets default values for this actor's properties
+	AJellyActor();
+
+protected:
+	// Called when the game starts or when spawned
+	virtual void BeginPlay() override;
+	UPROPERTY(EditAnywhere)
+	FJellyStatus status;
+public:	
+	// Called every frame
+	virtual void Tick(float DeltaTime) override;
+
+};

--- a/JellyDemo/Source/JellyDemo/JellyStatus.h
+++ b/JellyDemo/Source/JellyDemo/JellyStatus.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "JellyStatus.generated.h"
+
+USTRUCT(Atomic, BlueprintType)
+struct FJellyStatus
+{
+    GENERATED_USTRUCT_BODY()
+
+public:
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 aggression = 50;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 activity = 50;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 reproductivity = 50;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite)
+        int32 endurability = 50;
+};
+


### PR DESCRIPTION
Add an example code to use header file that defines basic properties of Jelly actor with default.